### PR TITLE
Obisdian vault removed from yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "task-watcher"
+name = "tasks-watcher"
 version = "0.1.0"
 dependencies = [
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "task-watcher"
+name = "tasks-watcher"
 version = "0.1.0"
 edition = "2021"
 authors = ["Gianoberto Giampieri giano.giampieri@proton.me"]
@@ -10,6 +10,16 @@ repository = "https://github.com/goldegard/task-watcher"
 categories = ["development-tools", "utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[packge.metadata.deb]
+depends = "$auto. systemd"
+extendend-description = "Simple task watcher for your tasks."
+section = "utils"
+priority = "optional"
+assets = [
+	["target/release/tasks-watcher", "/usr/bin/tasks-watcher", "755"],
+	["debian/tasks-watcher.service", "/etc/systemd/system/tasks-watcher.service", "644"],
+]
 
 [dependencies]
 chrono = "0.4.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ section = "utils"
 priority = "optional"
 assets = [
 	["target/release/tasks-watcher", "/usr/bin/tasks-watcher", "755"],
-	["debian/tasks-watcher.service", "/etc/systemd/system/tasks-watcher.service", "644"],
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -16,16 +16,37 @@ Set the following environment variables or create a `.env` file in the root of t
 - `JIRA_URL`: Url of your Jira instance
 
 ## Configuration file
-To setup the rest of the configuration, you'll need to create a `yaml` config file,
-containing fields that will be parsed to populate the config object.
+You'll need to create a `yaml` config file,
+containing fields that will be parsed to populate the config object. Look at the [Config](src/config.rs) struct to see all available fields.
 
 ## Usage
 ```bash
-cd task-watcher
-cargo run
+cd tasks-watcher
+cargo run -- -e <your-env>.env -c <your-config-file>.yaml
 ```
 
 Use: `tasks-watcher --help` to see all available options.
 
+## System-wide installation
+First install `cargo-deb` to create the deb package:
+`cargo install cargo-deb`
+
+Then run the following command to create the deb package and install it in your system:
+```bash
+cargo build --release && cargo deb
+sudo dpkg -i target/debian/tasks-watcher_0.1.0-1_amd64.deb
+```
+
+## Systemd service
+This utility can be used as a systemd service, unfortunately at the present moment `cargo deb` doesn't support user systemd service. This is needed here, because the service is supposed to run as a user service, using per-user configuration files.
+
+To enable the systemd service: move the `task-watcher.service` file to `/etc/systemd/user/`, and run the following commands:
+```bash
+systemctl --user daemon-reload
+systemctl --user enable tasks-watcher
+systemctl --user start tasks-watcher
+```
+This will start the service and by default it will look for `config.yaml` and `env.env` in `~/.config/task-watcher/`.
+
 ## TODOs
-- [ ] Use of `cargo deb` to crate a package and install the service: see [service-example](https://github.com/vasilakisfil/hello.service/tree/master) and [cargo-deb](https://github.com/kornelski/cargo-deb)
+- [ ] Use of `cargo deb` to install the service: see [service-example](https://github.com/vasilakisfil/hello.service/tree/master) and [cargo-deb](https://github.com/kornelski/cargo-deb)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ At the moment it supports GitHub and Jira as task sources and Obsidian as the de
 ## Env variables
 Set the following environment variables or create a `.env` file in the root of the project with the following content:
 - `GITHUB_TOKEN`: GitHub token to access the GitHub API
-- `OBSIDIAN_VAULT`: Path to your obisidian vault
+- `OBSIDIAN_VAULT_PATH`: Path to your obisidian vault
 - `FILTER_MY_TASK`: Filter only tasks assigned to you
 - `JIRA_USER`: Jira user email
 - `JIRA_TOKEN`: Jira API token

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Task Watcher
+# Tasks Watcher
 
 Simple Rust utility to poll tasks and save them in your Obsidian daily task note.
 
@@ -25,4 +25,7 @@ cd task-watcher
 cargo run
 ```
 
-Use: `task-watcher --help` to see all available options.
+Use: `tasks-watcher --help` to see all available options.
+
+## TODOs
+- [ ] Use of `cargo deb` to crate a package and install the service: see [service-example](https://github.com/vasilakisfil/hello.service/tree/master) and [cargo-deb](https://github.com/kornelski/cargo-deb)

--- a/debian/tasks-watcher.service
+++ b/debian/tasks-watcher.service
@@ -1,0 +1,14 @@
+[Unit]
+AssertPathExists=/usr/bin/tasks-watcher
+Description=Tasks watcher daemon
+
+[Service]
+WorkingDirectory=~
+ExecStart=/usr/bin/tasks-watcher -e ~/.tasks-watcher/env.env -c ~/.tasks-watcher/config.yaml
+Restart=always
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+Alias=tasks-watcher
+WantedBy=default.target

--- a/debian/tasks-watcher.service
+++ b/debian/tasks-watcher.service
@@ -1,11 +1,13 @@
 [Unit]
 AssertPathExists=/usr/bin/tasks-watcher
+After=network.target
 Description=Tasks watcher daemon
 
 [Service]
 WorkingDirectory=~
-ExecStart=/usr/bin/tasks-watcher -e ~/.tasks-watcher/env.env -c ~/.tasks-watcher/config.yaml
+ExecStart=/usr/bin/tasks-watcher -e %h/.config/tasks-watcher/env.env -c %h/.config/tasks-watcher/config.yaml
 Restart=always
+RestartSec=1
 PrivateTmp=true
 NoNewPrivileges=true
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use dotenv::dotenv;
-
 mod config;
 use config::Config;
 
@@ -47,7 +45,6 @@ async fn main() {
         let jira_source = sources::jira::JiraSource::new();
 
         let obsidian_handler = obsidian_handler::ObsidianHandler::new(
-            config.obsidian_handler.vault_path,
             config.obsidian_handler.daily_notes_path,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ struct Args {
     // Path to the .env file
     #[clap(short, long)]
     env_file: Option<String>,
-    
+
     // Path to the configuration yaml file
     #[clap(short, long)]
-    config_file: Option<String>,
+    config_file: String,
 }
 
 #[tokio::main]
@@ -37,8 +37,8 @@ async fn main() {
 
     loop {
         // read config and reset tasks
-        let config = Config::from_file(args.config_file.as_ref().unwrap_or(&"config.yaml".to_string()));
-        
+        let config = Config::from_file(&args.config_file);
+
         // instantiate sources
         let gh_source = sources::github::GitHubSource::new(
             config.github_config.current_user,

--- a/src/obsidian_handler.rs
+++ b/src/obsidian_handler.rs
@@ -9,28 +9,28 @@ use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ObsidianHandler {
-    pub vault_path: String,
     pub daily_notes_path: String,
     #[serde(skip)]
     task_tag_map: std::collections::HashMap<TaskSource, String>,
+    #[serde(skip)]
+    pub vault_path: String,
 }
 
 impl ObsidianHandler {
-    pub fn new(vault_path: String, daily_note_path: String) -> Self {
+    pub fn new(daily_note_path: String) -> Self {
         let mut task_tag_map: std::collections::HashMap<TaskSource, String> =
             std::collections::HashMap::new();
         task_tag_map.insert(TaskSource::PullRequest, "#todo/work/pr".to_string());
         task_tag_map.insert(TaskSource::Issue, "#todo/work/tasks".to_string());
         task_tag_map.insert(TaskSource::JiraTicket, "#todo/work/jira".to_string());
 
+        let vault_path = std::env::var("OBSIDIAN_VAULT_PATH").expect("OBSIDIAN_VAULT_PATH not set");
+
         ObsidianHandler {
-            vault_path: ObsidianHandler::resolve(&vault_path),
             daily_notes_path: daily_note_path,
             task_tag_map,
+            vault_path,
         }
-    }
-    pub fn resolve(vault_path: &String) -> String {
-        std::env::var(vault_path).expect("VAULT_PATH not set")
     }
 
     pub fn calculate_sha256(input: &str) -> String {


### PR DESCRIPTION
Since the vault path was resolved using the env anyway, it doesn't make sense to keep it in the config.