### PR TITLE
Support write on a single file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serde_yaml::{self};
-use crate::obsidian_handler::ObsidianHandler;
+use crate::obsidian_handler::ObsidianConfig;
 use crate::sources::github::GitHubSource;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config{
     pub github_config: GitHubSource,
     pub poll_interval: u64, // in minutes
-    pub obsidian_handler: ObsidianHandler,
+    pub obsidian_handler: ObsidianConfig,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ async fn main() {
         let jira_source = sources::jira::JiraSource::new();
 
         let obsidian_handler = obsidian_handler::ObsidianHandler::new(
-            config.obsidian_handler.daily_notes_path,
+            config.obsidian_handler.notes_path, config.obsidian_handler.daily_notes,
         );
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ async fn main() {
         let jira_source = sources::jira::JiraSource::new();
 
         let obsidian_handler = obsidian_handler::ObsidianHandler::new(
-            config.obsidian_handler.notes_path, config.obsidian_handler.daily_notes,
+            config.obsidian_handler.clone(),
         );
 
 

--- a/src/obsidian_handler.rs
+++ b/src/obsidian_handler.rs
@@ -7,18 +7,21 @@ use std::io::Write;
 use std::io::{self, BufRead};
 use std::path::Path;
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ObsidianHandler {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ObsidianConfig {
     pub notes_path: String,
     pub daily_notes: bool,
-    #[serde(skip)]
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ObsidianHandler {
+    pub config: ObsidianConfig,
     task_tag_map: std::collections::HashMap<TaskSource, String>,
-    #[serde(skip)]
     pub vault_path: String,
 }
 
 impl ObsidianHandler {
-    pub fn new(notes_path: String, daily_notes: bool) -> Self {
+    pub fn new(config: ObsidianConfig) -> Self {
         let mut task_tag_map: std::collections::HashMap<TaskSource, String> =
             std::collections::HashMap::new();
         task_tag_map.insert(TaskSource::PullRequest, "#todo/work/pr".to_string());
@@ -28,8 +31,7 @@ impl ObsidianHandler {
         let vault_path = std::env::var("OBSIDIAN_VAULT_PATH").expect("OBSIDIAN_VAULT_PATH not set");
 
         ObsidianHandler {
-            notes_path,
-            daily_notes,
+            config,
             task_tag_map,
             vault_path,
         }
@@ -68,10 +70,10 @@ impl HandleTask for ObsidianHandler {
     fn add_tasks(&self, tasks: Vec<Task>) {
         let today = self.today();
         let file_path: String;
-        if self.daily_notes {
-            file_path = format!("{}/{}/{}.md", self.vault_path, self.notes_path, today);
+        if self.config.daily_notes {
+            file_path = format!("{}/{}/{}.md", self.vault_path, self.config.notes_path, today);
         } else {
-            file_path = format!("{}/{}/tasks.md", self.vault_path, self.notes_path);
+            file_path = format!("{}/{}/tasks.md", self.vault_path, self.config.notes_path);
         }
 
         // create the file or fail if it exists

--- a/src/sources/jira.rs
+++ b/src/sources/jira.rs
@@ -15,17 +15,19 @@ impl JiraSource {
         let user = std::env::var("JIRA_USER").expect("JIRA_USER not found");
         let token = std::env::var("JIRA_TOKEN").expect("JIRA_TOKEN not found");
         let url = std::env::var("JIRA_URL").expect("JIRA_URL not found");
-        
+
         JiraSource { user, url, token }
     }
 }
-
 
 impl Fetch<task::Task> for JiraSource {
     async fn fetch(&self, _filter_my_task: bool) -> Vec<task::Task> {
         let client = reqwest::Client::new();
         let response = client
-            .get(&format!("{}/rest/api/2/search?{}", self.url, r#"jql=assignee=currentuser() AND status!=Done"#))
+            .get(&format!(
+                "{}/rest/api/2/search?{}",
+                self.url, r#"jql=assignee=currentuser() AND status!=Done"#
+            ))
             .basic_auth(&self.user, Some(&self.token))
             .header("Accept", "application/json")
             .send()
@@ -33,19 +35,40 @@ impl Fetch<task::Task> for JiraSource {
             .expect("Could not fetch Jira tasks");
 
         let body = response.text().await.expect("Could not read response body");
-        let jira_tasks: serde_json::Value = serde_json::from_str(&body).expect("Could not parse JSON");
+        let jira_tasks: serde_json::Value =
+            serde_json::from_str(&body).expect("Could not parse JSON");
 
         let mut tasks = vec![];
-        for issue in jira_tasks["issues"].as_array().expect("Could not find issues") {
+        for issue in jira_tasks["issues"]
+            .as_array()
+            .expect("Could not find issues")
+        {
             let key = issue["key"].as_str().expect("Could not find key");
-            let issue_url  = format!("{}/browse/{}", self.url, key);
-            let parent_issue = issue["fields"]["parent"]["fields"]["summary"].as_str().unwrap_or("No parent");
+            let issue_url = format!("{}/browse/{}", self.url, key);
+            let parent_issue = issue["fields"]["parent"]["fields"]["summary"]
+                .as_str()
+                .unwrap_or("No parent");
             let issue_summary = issue["fields"]["summary"].as_str().unwrap_or("No summary");
+            let status = match issue["fields"]["status"]["name"]
+                .as_str()
+                .unwrap_or("No status")
+            {
+                "In Progress" => task::TaskStatus::InProgress,
+                "Selected For Development" => task::TaskStatus::SelectedForDevelopment,
+                "Blocked" => task::TaskStatus::Blocked,
+                "Review" => task::TaskStatus::Review,
+                "TODO" => task::TaskStatus::Todo,
+                "Done" => task::TaskStatus::Done,
+                _ => task::TaskStatus::Open,
+            };
 
             let task = task::Task {
-                name: format!("<a href={}>{}</a>: {} - {}", issue_url, key, issue_summary, parent_issue),
+                name: format!(
+                    "<a href={}>{}</a>: {} - {}",
+                    issue_url, key, issue_summary, parent_issue
+                ),
                 source: task::TaskSource::JiraTicket,
-                status: task::TaskStatus::Open,
+                status,
             };
             tasks.push(task);
         }
@@ -56,8 +79,8 @@ impl Fetch<task::Task> for JiraSource {
 
 #[cfg(test)]
 mod tests {
-    use dotenv::dotenv;
     use super::*;
+    use dotenv::dotenv;
 
     #[test]
     fn instantiation_test() {

--- a/src/task.rs
+++ b/src/task.rs
@@ -13,10 +13,15 @@ pub enum TaskSource {
     JiraTicket
 }
 
+#[derive(PartialEq)]
 pub enum TaskStatus {
-    Open,
+    Todo,
+    SelectedForDevelopment,
     InProgress,
-    Done
+    Blocked,
+    Review,
+    Done,
+    Open,
 }
 
 use std::fmt;
@@ -34,8 +39,12 @@ impl fmt::Display for TaskSource {
 impl fmt::Display for TaskStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            TaskStatus::Todo => write!(f, "TODO"),
+            TaskStatus::SelectedForDevelopment => write!(f, "Selected For Development"),
             TaskStatus::Open => write!(f, "Open"),
             TaskStatus::InProgress => write!(f, "In Progress"),
+            TaskStatus::Blocked => write!(f, "Blocked"),
+            TaskStatus::Review => write!(f, "Review"),
             TaskStatus::Done => write!(f, "Done"),
         }
     }


### PR DESCRIPTION
This PR introduces the possibility to write the tasks updates in a single file. This is useful if you want to avoid having task duplicates in different daily notes.
Writing on daily notes is still supported using the `daily_notes=true` in config. Example:
```yaml
obsidian_handler:
  notes_path: "work/tasks"
  daily_notes: false
```

This PR also decouples ObisdianHandler from it's config. That was a major oversight.